### PR TITLE
Fix: Correct path for landing page background image

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&family=Great+Vibes&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css" />
   </head>
-  <body class="landing" style="--bg-url:url('img/front_pose_chin.jpeg')">
+  <body class="landing" style="background-image: url('img/front_pose_chin.jpeg')">
     <div class="overlay"></div>
     <main class="gate">
       <h1 class="script">You've got the keys to my heart</h1>


### PR DESCRIPTION
The landing page was failing to load its background image, resulting in a 404 error.

The issue was caused by incorrect path resolution for a URL defined within a CSS custom property. The path was being resolved relative to the stylesheet instead of the HTML document.

This change fixes the issue by setting the 'background-image' property directly in an inline style on the 'index.html' page. This ensures the image path is resolved correctly relative to the document root, eliminating the 404 error.