### PR TITLE
fix: Update page titles to a more personal message

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>You've got the keys to my heart</title>
+    <title>mysuperwoman💕</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&family=Great+Vibes&display=swap" rel="stylesheet">

--- a/main.html
+++ b/main.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>For My Grad Queen</title>
+    <title>mysuperwoman💕</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&family=Great+Vibes&display=swap" rel="stylesheet">


### PR DESCRIPTION
As requested, this commit updates the `<title>` tag in both `index.html` and `main.html`.

The previous titles ("You've got the keys to my heart" and "For My Grad Queen") have been replaced with "mysuperwoman💕" to give the site a more personal and consistent feel.