### PR TITLE
feat: Add balloon animation on gallery image click

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -164,7 +164,10 @@ h2 { color: var(--brown-500); }
 .accent-pill { display:inline-block; padding:.35rem .75rem; border-radius:999px; background: var(--ash-100); color: var(--blue-700); font-weight:700; margin:.15rem .25rem 0 0; border:1px solid #e6e8eb; }
 
 /* Gallery cards with captions */
-.gallery .grid > div { position: relative; }
+.gallery .grid > div {
+  position: relative;
+  transition: transform 0.2s ease-out, box-shadow 0.2s ease-out;
+}
 .caption { position:absolute; left:10px; right:10px; bottom:10px; color:#fff; font-weight:600; text-shadow:0 2px 8px rgba(0,0,0,.6); background: linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,.45) 100%); padding:.5rem .75rem; border-radius:12px;}
 
 /* Floating scroll-to-top heart */
@@ -217,3 +220,28 @@ h2 { color: var(--brown-500); }
   transform: translateY(0);
 }
 
+.gallery .grid > div.image-tapped {
+  transform: scale(1.05);
+  box-shadow: 0 8px 30px hsla(207, 79%, 54%, 0.4);
+}
+
+.balloon {
+  position: absolute;
+  width: 20px;
+  height: 25px;
+  background-color: var(--blue-600);
+  border-radius: 50%;
+  opacity: 0.9;
+  z-index: 10;
+  pointer-events: none;
+}
+.balloon::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--blue-600);
+}

--- a/js/app.js
+++ b/js/app.js
@@ -133,4 +133,30 @@
   }
 })();
 
+// Balloon animation for gallery clicks
+function spawnBalloon(x, y) {
+  const el = document.createElement('div');
+  el.className = 'balloon';
+  // Use the #hearts container so balloons appear under the overlay
+  const container = document.getElementById('hearts') || document.body;
+  container.appendChild(el);
+
+  el.style.left = x + 'px';
+  el.style.top = y + 'px';
+
+  const driftX = (Math.random() - 0.5) * 150;
+  const driftY = -window.innerHeight - Math.random() * 100 - 150;
+
+  el.animate([
+    { transform: 'translate(-50%, 0) scale(0)', opacity: 1 },
+    { transform: `translate(${driftX}px, ${driftY}px) scale(1.2)`, opacity: 0 }
+  ], {
+    duration: 3000 + Math.random() * 1500,
+    easing: 'ease-out',
+    fill: 'forwards'
+  });
+
+  setTimeout(() => el.remove(), 5000);
+}
+window.spawnBalloon = spawnBalloon;
 

--- a/main.html
+++ b/main.html
@@ -93,6 +93,27 @@
       }
       galleryFiles.forEach(name => addCard('img/' + name));
 
+      // Add click listener for balloon animation
+      const galleryItems = document.querySelectorAll('.gallery .grid > div');
+      galleryItems.forEach(item => {
+        item.addEventListener('click', () => {
+          // Pop out effect
+          item.classList.add('image-tapped');
+          setTimeout(() => item.classList.remove('image-tapped'), 400);
+
+          // Balloon burst
+          const rect = item.getBoundingClientRect();
+          const startX = rect.left + rect.width / 2;
+          const startY = rect.bottom;
+
+          for (let i = 0; i < 5; i++) {
+            setTimeout(() => {
+              if (window.spawnBalloon) window.spawnBalloon(startX, startY);
+            }, i * 100);
+          }
+        });
+      });
+
       // Captions for images (same order as galleryFiles)
       window.galleryCaptions = [
         'You are my queen, always and forever.',


### PR DESCRIPTION
This commit introduces a new interactive feature to the main page's photo gallery.

When a user clicks on a gallery image, two effects are triggered:
1.  The image and its container pop forward with a scale transform and a box-shadow, providing tactile feedback.
2.  A burst of five blue balloons is generated, animating up from the bottom of the clicked image and fading out.

This was implemented by:
- Adding new CSS classes for the pop-out effect and balloon styling.
- Creating a new `spawnBalloon` function in `js/app.js` to handle the animation.
- Adding a click event listener to the gallery items in `main.html`.